### PR TITLE
post 도메인 코어기능 구현 및 spotless 적용

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/api/src/main/java/com/flab/ccinside/api/ApiApplication.java
+++ b/api/src/main/java/com/flab/ccinside/api/ApiApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class ApiApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(ApiApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(ApiApplication.class, args);
+  }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
@@ -33,7 +33,8 @@ public class PostUserController {
   }
 
   @GetMapping("/{galleryNo}/posts")
-  public Page<PostData> viewPosts(@PathVariable Long galleryNo, @PageableDefault Pageable pageable) {
+  public Page<PostData> viewPosts(
+      @PathVariable Long galleryNo, @PageableDefault Pageable pageable) {
     return postUseCase.viewPosts(galleryNo, pageable);
   }
 

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
@@ -1,10 +1,16 @@
 package com.flab.ccinside.api.trendingpost.adapter.in.web;
 
+import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
 import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
 import com.flab.ccinside.api.trendingpost.application.port.in.PostUseCase;
+import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,5 +30,15 @@ public class PostUserController {
   public void create(@PathVariable Long galleryNo, @RequestBody @Valid CreatePostCommand command) {
     var request = command.toBuilder().galleryNo(galleryNo).build();
     postUseCase.create(request);
+  }
+
+  @GetMapping("/{galleryNo}/posts")
+  public Page<PostData> viewPosts(@PathVariable Long galleryNo, @PageableDefault Pageable pageable) {
+    return postUseCase.viewPosts(galleryNo, pageable);
+  }
+
+  @GetMapping("/{galleryNo}/posts/{postId}")
+  public PostData viewPostDetails(@PathVariable Long galleryNo, @PathVariable PostId postId) {
+    return postUseCase.viewPostDetail(postId);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/PostUserController.java
@@ -1,0 +1,28 @@
+package com.flab.ccinside.api.trendingpost.adapter.in.web;
+
+import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
+import com.flab.ccinside.api.trendingpost.application.port.in.PostUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class PostUserController {
+
+  private final PostUseCase postUseCase;
+
+  @PostMapping("/{galleryNo}/posts")
+  @ResponseStatus(HttpStatus.CREATED)
+  public void create(@PathVariable Long galleryNo, @RequestBody @Valid CreatePostCommand command) {
+    var request = command.toBuilder().galleryNo(galleryNo).build();
+    postUseCase.create(request);
+  }
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/TrendingPostController.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/web/TrendingPostController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -27,14 +26,16 @@ class TrendingPostController {
 
   @PostMapping("/{galleryNo}/posts")
   @ResponseStatus(HttpStatus.OK)
-  void publishNewTrendingPosts(@PathVariable Long galleryNo, @RequestParam(defaultValue = "ONE_HOUR") UnitTime unitTime) {
+  void publishNewTrendingPosts(
+      @PathVariable Long galleryNo, @RequestParam(defaultValue = "ONE_HOUR") UnitTime unitTime) {
     var command = PublishTrendingPostCommand.of(galleryNo, unitTime);
     trendingPostUseCase.publishNewTrendingPosts(command);
   }
 
   @GetMapping("/{galleryNo}/posts")
   @ResponseStatus(HttpStatus.OK)
-  List<TrendingPostData> getTrendingPosts(@PathVariable Long galleryNo, @RequestParam(defaultValue = "ONE_HOUR") UnitTime unitTime) {
+  List<TrendingPostData> getTrendingPosts(
+      @PathVariable Long galleryNo, @RequestParam(defaultValue = "ONE_HOUR") UnitTime unitTime) {
     return trendingPostUseCase.getTrendingPosts(galleryNo, unitTime);
   }
 

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostEntity.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostEntity.java
@@ -1,10 +1,7 @@
 package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 
-import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,8 +23,7 @@ public class PostEntity {
   @Column(name = "id")
   private Long id;
 
-  @Column
-  private String title;
+  @Column private String title;
 
   @Column(name = "author_no")
   private Long authorNo;

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostEntity.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostEntity.java
@@ -23,8 +23,8 @@ public class PostEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "post_no")
-  private Long postNo;
+  @Column(name = "id")
+  private Long id;
 
   @Column
   private String title;
@@ -34,13 +34,6 @@ public class PostEntity {
 
   @Column(name = "gallery_no")
   private Long galleryNo;
-
-  @Column(name = "post_views")
-  private Integer postViews;
-
-  @Enumerated(EnumType.STRING)
-  @Column(name = "unit_time")
-  private UnitTime unitTime;
 
   @Column(name = "created_at")
   private LocalDateTime createdAt;

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostId.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostId.java
@@ -1,6 +1,5 @@
 package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.constraints.NotNull;
@@ -16,5 +15,4 @@ public record PostId(@NotNull @JsonValue Long value) implements Serializable {
   public static PostId from(@NotNull String value) {
     return new PostId(Long.valueOf(value));
   }
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostId.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostId.java
@@ -1,0 +1,20 @@
+package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+
+public record PostId(@NotNull @JsonValue Long value) implements Serializable {
+
+  @JsonCreator
+  public static PostId from(@NotNull Long value) {
+    return new PostId(value);
+  }
+
+  public static PostId from(@NotNull String value) {
+    return new PostId(Long.valueOf(value));
+  }
+
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaMapper.java
@@ -3,22 +3,21 @@ package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 import com.flab.ccinside.api.trendingpost.domain.Post;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
 class PostJpaMapper {
 
   Post map(PostEntity post) {
-    return new Post(post.getPostNo(), post.getTitle(), post.getAuthorNo(), post.getGalleryNo(), post.getPostViews(),
-        post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), post.getUnitTime()
+    return new Post(PostId.from(post.getId()), post.getTitle(), post.getAuthorNo(), post.getGalleryNo(),
+        post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     );
   }
 
-  //TODO: postNo 널포터질것같은데..?
   PostEntity map(Post post) {
     return new PostEntity(
-        post.getPostNo(), post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(), post.getPostViews(),
-        post.getUnitTime(),
+        Optional.ofNullable(post.getId()).map(PostId::value).orElse(null), post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(),
         LocalDateTime.parse(post.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     );
   }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaMapper.java
@@ -10,16 +10,20 @@ import org.springframework.stereotype.Component;
 class PostJpaMapper {
 
   Post map(PostEntity post) {
-    return new Post(PostId.from(post.getId()), post.getTitle(), post.getAuthorNo(), post.getGalleryNo(),
-        post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    );
+    return new Post(
+        PostId.from(post.getId()),
+        post.getTitle(),
+        post.getAuthorNo(),
+        post.getGalleryNo(),
+        post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
   }
 
   PostEntity map(Post post) {
     return new PostEntity(
-        Optional.ofNullable(post.getId()).map(PostId::value).orElse(null), post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(),
-        LocalDateTime.parse(post.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    );
+        Optional.ofNullable(post.getId()).map(PostId::value).orElse(null),
+        post.getPostTitle(),
+        post.getAuthorNo(),
+        post.getGalleryNo(),
+        LocalDateTime.parse(post.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME));
   }
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaRepository.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaRepository.java
@@ -1,10 +1,14 @@
 package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
 
   List<PostEntity> findByGalleryNo(Long galleryNo);
+
+  Page<PostEntity> findByGalleryNo(Long galleryNo, Pageable pageable);
 
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaRepository.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostJpaRepository.java
@@ -10,5 +10,4 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
   List<PostEntity> findByGalleryNo(Long galleryNo);
 
   Page<PostEntity> findByGalleryNo(Long galleryNo, Pageable pageable);
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -2,10 +2,12 @@ package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 
 import com.flab.ccinside.api.trendingpost.application.port.out.CreatePostPort;
 import com.flab.ccinside.api.trendingpost.application.port.out.LoadPostPort;
-import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import com.flab.ccinside.api.trendingpost.domain.Post;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,6 +18,11 @@ class PostPersistenceAdapter implements LoadPostPort, CreatePostPort {
   private final PostJpaMapper mapper;
 
   @Override
+  public Optional<Post> loadPost(PostId postId) {
+    return postRepository.findById(postId.value()).map(mapper::map);
+  }
+
+  @Override
   public List<Post> loadPosts(Long galleryNo) {
     var postEntities = postRepository.findByGalleryNo(galleryNo);
 
@@ -23,8 +30,8 @@ class PostPersistenceAdapter implements LoadPostPort, CreatePostPort {
   }
 
   @Override
-  public List<Post> loadPosts(Long galleryNo, UnitTime unitTime) {
-    return null;
+  public Page<Post> loadPostsWithPage(Long galleryNo, Pageable pageable) {
+    return postRepository.findByGalleryNo(galleryNo, pageable).map(mapper::map);
   }
 
   @Override

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.flab.ccinside.api.trendingpost.adapter.out.persistence.post;
 
+import com.flab.ccinside.api.trendingpost.application.port.out.CreatePostPort;
 import com.flab.ccinside.api.trendingpost.application.port.out.LoadPostPort;
 import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import com.flab.ccinside.api.trendingpost.domain.Post;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-class PostPersistenceAdapter implements LoadPostPort {
+class PostPersistenceAdapter implements LoadPostPort, CreatePostPort {
 
   private final PostJpaRepository postRepository;
   private final PostJpaMapper mapper;
@@ -24,5 +25,11 @@ class PostPersistenceAdapter implements LoadPostPort {
   @Override
   public List<Post> loadPosts(Long galleryNo, UnitTime unitTime) {
     return null;
+  }
+
+  @Override
+  public void createPost(Post post) {
+    var postEntity = mapper.map(post);
+    postRepository.save(postEntity);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostEntity.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostEntity.java
@@ -29,8 +29,7 @@ public class TrendingPostEntity {
   @Column(name = "post_no")
   private Long postNo;
 
-  @Column
-  private String title;
+  @Column private String title;
 
   @Column(name = "author_no")
   private Long authorNo;
@@ -47,5 +46,4 @@ public class TrendingPostEntity {
 
   @Column(name = "created_at")
   private LocalDateTime createdAt;
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostJpaMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostJpaMapper.java
@@ -11,30 +11,32 @@ class TrendingPostJpaMapper {
 
   List<TrendingPostEntity> mapToEntity(List<TrendingPost> trendingPosts) {
     return trendingPosts.stream()
-                                .map(m -> new TrendingPostEntity(
-                                    m.getTrendingPostNo(),
-                                    m.getTrendingPostNo(),
-                                    m.getPostTitle(),
-                                    m.getAuthorNo(),
-                                    m.getGalleryNo(),
-                                    1, // view 수정..
-                                    m.getUnitTime(),
-                                    LocalDateTime.parse(m.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                                ))
-                                .toList();
+        .map(
+            m ->
+                new TrendingPostEntity(
+                    m.getTrendingPostNo(),
+                    m.getTrendingPostNo(),
+                    m.getPostTitle(),
+                    m.getAuthorNo(),
+                    m.getGalleryNo(),
+                    1, // view 수정..
+                    m.getUnitTime(),
+                    LocalDateTime.parse(m.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
+        .toList();
   }
 
   List<TrendingPost> mapToDomain(List<TrendingPostEntity> trendingPosts) {
-    return trendingPosts.stream().map(
-        m -> new TrendingPost(
-            m.getTrendingPostNo(),
-            m.getPostNo(),
-            m.getTitle(),
-            m.getAuthorNo(),
-            m.getGalleryNo(),
-            m.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-            m.getUnitTime()
-        )
-    ).toList();
+    return trendingPosts.stream()
+        .map(
+            m ->
+                new TrendingPost(
+                    m.getTrendingPostNo(),
+                    m.getPostNo(),
+                    m.getTitle(),
+                    m.getAuthorNo(),
+                    m.getGalleryNo(),
+                    m.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    m.getUnitTime()))
+        .toList();
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostJpaMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostJpaMapper.java
@@ -17,7 +17,7 @@ class TrendingPostJpaMapper {
                                     m.getPostTitle(),
                                     m.getAuthorNo(),
                                     m.getGalleryNo(),
-                                    m.getPostViews(),
+                                    1, // view 수정..
                                     m.getUnitTime(),
                                     LocalDateTime.parse(m.getCreatedAt(), DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                                 ))
@@ -32,7 +32,6 @@ class TrendingPostJpaMapper {
             m.getTitle(),
             m.getAuthorNo(),
             m.getGalleryNo(),
-            m.getPostViews(),
             m.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             m.getUnitTime()
         )

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostPersistenceAdapter.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/persistence/trendingpost/TrendingPostPersistenceAdapter.java
@@ -7,7 +7,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-
 @Component
 @RequiredArgsConstructor
 class TrendingPostPersistenceAdapter implements TrendingPostPort {

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
@@ -1,10 +1,14 @@
 package com.flab.ccinside.api.trendingpost.application;
 
+import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
+import com.flab.ccinside.api.trendingpost.domain.Post;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PostMapper {
+class PostMapper {
 
-
-
+  PostData map(Post post) {
+    return new PostData(
+        post.getId().value(), post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(), 1, post.getCreatedAt());
+  }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
@@ -1,0 +1,10 @@
+package com.flab.ccinside.api.trendingpost.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostMapper {
+
+
+
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostMapper.java
@@ -9,6 +9,11 @@ class PostMapper {
 
   PostData map(Post post) {
     return new PostData(
-        post.getId().value(), post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(), 1, post.getCreatedAt());
+        post.getId().value(),
+        post.getPostTitle(),
+        post.getAuthorNo(),
+        post.getGalleryNo(),
+        1,
+        post.getCreatedAt());
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
@@ -1,11 +1,18 @@
 package com.flab.ccinside.api.trendingpost.application;
 
+import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
 import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
 import com.flab.ccinside.api.trendingpost.application.port.in.PostUseCase;
 import com.flab.ccinside.api.trendingpost.application.port.out.CreatePostPort;
+import com.flab.ccinside.api.trendingpost.application.port.out.LoadPostPort;
+import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
 import com.flab.ccinside.api.trendingpost.domain.Post;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,10 +23,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostUserService implements PostUseCase {
 
   private final CreatePostPort createPostPort;
+  private final LoadPostPort loadPostPort;
+  private final PostMapper mapper;
 
   @Override
   public void create(CreatePostCommand command) {
     var post = Post.createWithoutId(command);
     createPostPort.createPost(post);
+  }
+
+  @Override
+  public PostData viewPostDetail(PostId postId) {
+    return loadPostPort.loadPost(postId)
+                       .map(mapper::map)
+                       .orElseThrow(EntityNotFoundException::new);
+  }
+
+  @Override
+  public Page<PostData> viewPosts(Long galleryNo, Pageable pageable) {
+    return loadPostPort.loadPostsWithPage(galleryNo, pageable)
+                       .map(mapper::map);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
@@ -1,0 +1,25 @@
+package com.flab.ccinside.api.trendingpost.application;
+
+import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
+import com.flab.ccinside.api.trendingpost.application.port.in.PostUseCase;
+import com.flab.ccinside.api.trendingpost.application.port.out.CreatePostPort;
+import com.flab.ccinside.api.trendingpost.domain.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostUserService implements PostUseCase {
+
+  private final CreatePostPort createPostPort;
+
+  @Override
+  public void create(CreatePostCommand command) {
+    var post = Post.createWithoutId(command);
+    createPostPort.createPost(post);
+  }
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/PostUserService.java
@@ -8,7 +8,6 @@ import com.flab.ccinside.api.trendingpost.application.port.out.LoadPostPort;
 import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
 import com.flab.ccinside.api.trendingpost.domain.Post;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -34,14 +33,11 @@ public class PostUserService implements PostUseCase {
 
   @Override
   public PostData viewPostDetail(PostId postId) {
-    return loadPostPort.loadPost(postId)
-                       .map(mapper::map)
-                       .orElseThrow(EntityNotFoundException::new);
+    return loadPostPort.loadPost(postId).map(mapper::map).orElseThrow(EntityNotFoundException::new);
   }
 
   @Override
   public Page<PostData> viewPosts(Long galleryNo, Pageable pageable) {
-    return loadPostPort.loadPostsWithPage(galleryNo, pageable)
-                       .map(mapper::map);
+    return loadPostPort.loadPostsWithPage(galleryNo, pageable).map(mapper::map);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/TrendingPostMapper.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/TrendingPostMapper.java
@@ -10,13 +10,11 @@ class TrendingPostMapper {
 
   public List<TrendingPostData> map(List<TrendingPost> trendingPost) {
 
-    return trendingPost.stream().map(
-        m -> new TrendingPostData(
-            m.getTrendingPostNo(),
-            m.getPostTitle(),
-            m.getGalleryNo(),
-            m.getCreatedAt()
-        )).toList();
+    return trendingPost.stream()
+        .map(
+            m ->
+                new TrendingPostData(
+                    m.getTrendingPostNo(), m.getPostTitle(), m.getGalleryNo(), m.getCreatedAt()))
+        .toList();
   }
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/TrendingPostService.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/TrendingPostService.java
@@ -7,8 +7,6 @@ import com.flab.ccinside.api.trendingpost.application.port.out.TrendingPostData;
 import com.flab.ccinside.api.trendingpost.application.port.out.TrendingPostPort;
 import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import com.flab.ccinside.api.trendingpost.domain.TrendingPost;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,12 +35,8 @@ class TrendingPostService implements TrendingPostUseCase {
   }
 
   @Override
-  public void addOnePostIntoTrendingList(Long postNo) {
-
-  }
+  public void addOnePostIntoTrendingList(Long postNo) {}
 
   @Override
-  public void deleteTrendingPost(Long postNo) {
-
-  }
+  public void deleteTrendingPost(Long postNo) {}
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/CreatePostCommand.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/CreatePostCommand.java
@@ -1,10 +1,8 @@
 package com.flab.ccinside.api.trendingpost.application.port.in;
 
-import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
-public record CreatePostCommand(@NotNull String title, @NotNull Long authorNo, @NotNull Long galleryNo, Integer postView) {
-
-}
+public record CreatePostCommand(
+    @NotNull String title, @NotNull Long authorNo, @NotNull Long galleryNo, Integer postView) {}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/CreatePostCommand.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/CreatePostCommand.java
@@ -1,0 +1,10 @@
+package com.flab.ccinside.api.trendingpost.application.port.in;
+
+import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record CreatePostCommand(@NotNull String title, @NotNull Long authorNo, @NotNull Long galleryNo, Integer postView) {
+
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
@@ -1,0 +1,7 @@
+package com.flab.ccinside.api.trendingpost.application.port.in;
+
+public interface PostUseCase {
+
+  void create(CreatePostCommand command);
+
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
@@ -2,7 +2,6 @@ package com.flab.ccinside.api.trendingpost.application.port.in;
 
 import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
 import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostUseCase.java
@@ -1,7 +1,16 @@
 package com.flab.ccinside.api.trendingpost.application.port.in;
 
+import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
+import com.flab.ccinside.api.trendingpost.application.port.out.PostData;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface PostUseCase {
 
   void create(CreatePostCommand command);
 
+  PostData viewPostDetail(PostId postId);
+
+  Page<PostData> viewPosts(Long galleryNo, Pageable pageable);
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PublishTrendingPostCommand.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PublishTrendingPostCommand.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.Value;
 
-//TODO: Validation 추가하기
+// TODO: Validation 추가하기
 @Value
 public class PublishTrendingPostCommand {
 

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/CreatePostPort.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/CreatePostPort.java
@@ -1,0 +1,8 @@
+package com.flab.ccinside.api.trendingpost.application.port.out;
+
+import com.flab.ccinside.api.trendingpost.domain.Post;
+
+public interface CreatePostPort {
+
+  void createPost(Post post);
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/LoadPostPort.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/LoadPostPort.java
@@ -12,6 +12,6 @@ public interface LoadPostPort {
   Optional<Post> loadPost(PostId postId);
 
   List<Post> loadPosts(Long galleryNo);
-  Page<Post> loadPostsWithPage(Long galleryNo, Pageable pageable);
 
+  Page<Post> loadPostsWithPage(Long galleryNo, Pageable pageable);
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/LoadPostPort.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/LoadPostPort.java
@@ -1,10 +1,17 @@
 package com.flab.ccinside.api.trendingpost.application.port.out;
 
+import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
 import com.flab.ccinside.api.trendingpost.domain.Post;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface LoadPostPort {
+
+  Optional<Post> loadPost(PostId postId);
+
   List<Post> loadPosts(Long galleryNo);
-  List<Post> loadPosts(Long galleryNo, UnitTime unitTime);
+  Page<Post> loadPostsWithPage(Long galleryNo, Pageable pageable);
 
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/PostData.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/PostData.java
@@ -1,5 +1,9 @@
 package com.flab.ccinside.api.trendingpost.application.port.out;
 
-public record PostData(Long postNo, String postTitle, Long authorNo, Long galleryNo, Integer postViews, String createdAt) {
-
-}
+public record PostData(
+    Long postNo,
+    String postTitle,
+    Long authorNo,
+    Long galleryNo,
+    Integer postViews,
+    String createdAt) {}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/TrendingPostData.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/TrendingPostData.java
@@ -1,20 +1,18 @@
 package com.flab.ccinside.api.trendingpost.application.port.out;
 
-
 import lombok.Builder;
 
 @Builder
-public record TrendingPostData(Long postNo, String postTitle, Long galleryNo,
-                               String createdAt) {
+public record TrendingPostData(Long postNo, String postTitle, Long galleryNo, String createdAt) {
 
-  public static TrendingPostData of(Long postNo, String postTitle, Long galleryNo,
-                                    String createdAt) {
+  public static TrendingPostData of(
+      Long postNo, String postTitle, Long galleryNo, String createdAt) {
 
     return TrendingPostData.builder()
-                           .postNo(postNo)
-                           .postTitle(postTitle)
-                           .galleryNo(galleryNo)
-                           .createdAt(createdAt)
-                           .build();
+        .postNo(postNo)
+        .postTitle(postTitle)
+        .galleryNo(galleryNo)
+        .createdAt(createdAt)
+        .build();
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/TrendingPostPort.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/TrendingPostPort.java
@@ -8,5 +8,4 @@ public interface TrendingPostPort {
   void publishTrendingPosts(List<TrendingPost> trendingPost);
 
   List<TrendingPost> getTrendingPosts(Long galleryNo, UnitTime unitTime);
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/Post.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/Post.java
@@ -2,7 +2,6 @@ package com.flab.ccinside.api.trendingpost.domain;
 
 import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
 import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
-import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.AllArgsConstructor;
@@ -28,5 +27,4 @@ public class Post {
     var createdAt = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     return new Post(null, command.title(), command.authorNo(), command.galleryNo(), createdAt);
   }
-
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/Post.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/Post.java
@@ -1,7 +1,12 @@
 package com.flab.ccinside.api.trendingpost.domain;
 
+import com.flab.ccinside.api.trendingpost.adapter.out.persistence.post.PostId;
+import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand;
 import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,15 +15,18 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(of = "id")
 public class Post {
 
-  //TODO: Long 대신 PostNo로 PK 변경?
-  private Long postNo;
+  private PostId id;
   private String postTitle;
   private Long authorNo;
   private Long galleryNo;
-  private Integer postViews;
   private String createdAt;
-  private UnitTime unitTime;
+
+  public static Post createWithoutId(CreatePostCommand command) {
+    var createdAt = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    return new Post(null, command.title(), command.authorNo(), command.galleryNo(), createdAt);
+  }
 
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/TrendingPost.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/TrendingPost.java
@@ -1,7 +1,6 @@
 package com.flab.ccinside.api.trendingpost.domain;
 
 import com.flab.ccinside.api.trendingpost.application.port.out.UnitTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -23,26 +22,25 @@ public class TrendingPost {
   private String createdAt;
   private UnitTime unitTime;
 
-  //TODO: 조회수 레디스로 분리..?
+  // TODO: 조회수 레디스로 분리..?
   public static List<TrendingPost> publishTrendingPost(List<Post> posts, UnitTime unitTime) {
-    var postDatas = posts.stream()
-                         .limit(10L)
-                         .collect(Collectors.toList());
+    var postDatas = posts.stream().limit(10L).collect(Collectors.toList());
 
     return TrendingPost.of(postDatas, unitTime);
   }
 
   public static List<TrendingPost> of(List<Post> posts, UnitTime unitTime) {
     return posts.stream()
-                    .map(m -> new TrendingPost(
-                        null,
-                        m.getId().value(),
-                        m.getPostTitle(),
-                        m.getAuthorNo(),
-                        m.getGalleryNo(),
-                        m.getCreatedAt(),
-                        unitTime
-                    ))
-                    .toList();
+        .map(
+            m ->
+                new TrendingPost(
+                    null,
+                    m.getId().value(),
+                    m.getPostTitle(),
+                    m.getAuthorNo(),
+                    m.getGalleryNo(),
+                    m.getCreatedAt(),
+                    unitTime))
+        .toList();
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/TrendingPost.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/domain/TrendingPost.java
@@ -20,14 +20,12 @@ public class TrendingPost {
   private String postTitle;
   private Long authorNo;
   private Long galleryNo;
-  private Integer postViews;
   private String createdAt;
   private UnitTime unitTime;
 
-  //TODO: 실시간 인기 게시글 비즈니스 로직 추가
+  //TODO: 조회수 레디스로 분리..?
   public static List<TrendingPost> publishTrendingPost(List<Post> posts, UnitTime unitTime) {
     var postDatas = posts.stream()
-                         .sorted(Comparator.comparing(Post::getPostViews).reversed())
                          .limit(10L)
                          .collect(Collectors.toList());
 
@@ -38,11 +36,10 @@ public class TrendingPost {
     return posts.stream()
                     .map(m -> new TrendingPost(
                         null,
-                        m.getPostNo(),
+                        m.getId().value(),
                         m.getPostTitle(),
                         m.getAuthorNo(),
                         m.getGalleryNo(),
-                        m.getPostViews(),
                         m.getCreatedAt(),
                         unitTime
                     ))

--- a/api/src/test/java/com/flab/ccinside/api/trendingpost/adapter/in/web/TrendingPostControllerTest.java
+++ b/api/src/test/java/com/flab/ccinside/api/trendingpost/adapter/in/web/TrendingPostControllerTest.java
@@ -25,11 +25,9 @@ import org.springframework.test.web.servlet.ResultActions;
 @AutoConfigureMockMvc
 class TrendingPostControllerTest {
 
-  @Autowired
-  MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-  @Autowired
-  TrendingPostUseCase trendingPostUseCase;
+  @Autowired TrendingPostUseCase trendingPostUseCase;
 
   ObjectMapper mapper;
 
@@ -41,30 +39,29 @@ class TrendingPostControllerTest {
 
   @Test
   void publishNewTrendingPosts() throws Exception {
-    //given
+    // given
 
-    //when
+    // when
     ResultActions result = mockMvc.perform(post("/api/v1/trending/{galleryNo}/posts", 1));
 
-    //then
+    // then
     result.andExpect(status().isOk());
-
   }
 
   @Test
   void getTrendingPosts() throws Exception {
-    //given
+    // given
 
-    //when
+    // when
     ResultActions result = mockMvc.perform(get("/api/v1/trending/{galleryNo}/posts", 1));
 
-    //then
-    result.andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("$.length()").isNotEmpty());
+    // then
+    result
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()").isNotEmpty());
   }
 
   @Test
-  void updateTrendingPosts() {
-  }
+  void updateTrendingPosts() {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'groovy'
+    id "com.diffplug.spotless" version '6.25.0'
+}
+
+subprojects {
+    apply plugin: 'groovy'
+    apply plugin: "com.diffplug.spotless"
+
+    spotless {
+        format 'misc', {
+            target '*.gradle', '*.md', '.gitignore'
+
+            trimTrailingWhitespace()
+            indentWithSpaces(2)
+            endWithNewline()
+        }
+        java {
+            importOrder()
+            removeUnusedImports()
+            indentWithSpaces(2)
+            googleJavaFormat()
+            formatAnnotations()
+        }
+
+        groovy {
+            importOrder()
+            excludeJava()
+        }
+    }
+}


### PR DESCRIPTION
실시간 인기 게시글 구현을 하다보니.. TrendingPost라는 도메인 이전에 Post 도메인이 필요하다고 느꼈습니다.

- convention을 위한 spotless 적용
- 게시글 관련 코어기능 구현

## 고민되는 부분
- `조회수`를 어떻게 구현할지?
  - Post 엔티티에 조회수가 들어가는건 너무 비효율로 보임
  - 레디스를 따로 두고 일정 주기마다 한 번에 업데이트 치는 방식??
 
우선 레디스로 조회수 기능 구현해보고, 피드백을 통해 수정하도록 하겠습니다 :)

![image](https://github.com/user-attachments/assets/636f811e-6b05-4579-8ae7-198ccd82ae30)
