### PR TITLE
리뷰 수정

### DIFF
--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
@@ -6,7 +6,6 @@ import com.flab.ccinside.api.trendingpost.application.port.in.UpdateViewCountCom
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +15,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class InMemoryMessageQueue {
 
-  public InMemoryMessageQueue(PostSystemUsecase postSystemUsecase, Queue<ViewPostEvent> queue) {
-    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+  public InMemoryMessageQueue(
+      PostSystemUsecase postSystemUsecase,
+      Queue<ViewPostEvent> queue,
+      ScheduledExecutorService executorService) {
 
     executorService.scheduleWithFixedDelay(
         () -> {

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
@@ -3,6 +3,8 @@ package com.flab.ccinside.api.trendingpost.adapter.in.message;
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import com.flab.ccinside.api.trendingpost.application.port.in.PostSystemUsecase;
 import com.flab.ccinside.api.trendingpost.application.port.in.UpdateViewCountCommand;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -17,17 +19,24 @@ public class InMemoryMessageQueue {
   public InMemoryMessageQueue(PostSystemUsecase postSystemUsecase, Queue<ViewPostEvent> queue) {
     ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
-    executorService.scheduleWithFixedDelay(() -> {
-      try {
-        ViewPostEvent event;
-        while ((event = queue.poll()) != null) {
-          log.info("View post event consumed. postId: {}", event.postId());
-          var command = new UpdateViewCountCommand(event.postId());
-          postSystemUsecase.updateViewCount(command);
-        }
-      } catch (Exception e) {
-        log.error("error: {}", e.getMessage());
-      }
-}, 10, 100, TimeUnit.MILLISECONDS);
+    executorService.scheduleWithFixedDelay(
+        () -> {
+          try {
+            List<UpdateViewCountCommand> commands = new ArrayList<>();
+            ViewPostEvent event;
+            while ((event = queue.poll()) != null) {
+              log.info("View post event consumed. postId: {}", event.postId());
+              var command = new UpdateViewCountCommand(event.postId());
+              postSystemUsecase.updateViewCount(command);
+              commands.add(command);
+            }
+            postSystemUsecase.persistViewCountsInBatch(commands);
+          } catch (Exception e) {
+            log.error("error: {}", e.getMessage());
+          }
+        },
+        10,
+        100,
+        TimeUnit.MILLISECONDS);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
@@ -3,38 +3,31 @@ package com.flab.ccinside.api.trendingpost.adapter.in.message;
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import com.flab.ccinside.api.trendingpost.application.port.in.PostSystemUsecase;
 import com.flab.ccinside.api.trendingpost.application.port.in.UpdateViewCountCommand;
-import jakarta.annotation.PostConstruct;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
+import java.util.Queue;
 import java.util.concurrent.Executors;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class InMemoryMessageQueue {
 
-  private final PostSystemUsecase postSystemUsecase;
-  private final BlockingQueue<ViewPostEvent> queue;
-  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  public InMemoryMessageQueue(PostSystemUsecase postSystemUsecase, Queue<ViewPostEvent> queue) {
+    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
-  @PostConstruct
-  public void init() {
-    executorService.submit(
-        () -> {
-          try {
-            while (true) {
-              var event = queue.take();
-              log.info("View post event consumed. postId: {}", event.postId());
-              var command = new UpdateViewCountCommand(event.postId());
-              postSystemUsecase.updateViewCount(command);
-            }
-          } catch (InterruptedException e) {
-            log.error("consume error: {}", e.getMessage());
-            throw new RuntimeException(e);
-          }
-        });
+    executorService.scheduleWithFixedDelay(() -> {
+      try {
+        ViewPostEvent event;
+        while ((event = queue.poll()) != null) {
+          log.info("View post event consumed. postId: {}", event.postId());
+          var command = new UpdateViewCountCommand(event.postId());
+          postSystemUsecase.updateViewCount(command);
+        }
+      } catch (Exception e) {
+        log.error("error: {}", e.getMessage());
+      }
+}, 10, 100, TimeUnit.MILLISECONDS);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueue.java
@@ -25,10 +25,14 @@ public class InMemoryMessageQueue {
       ScheduledExecutorService executorService) {
 
     executorService.scheduleWithFixedDelay(
-        createEventConsumerRunnable(postSystemUsecase, queue), INITIAL_DELAY, FIXED_DELAY, TimeUnit.MILLISECONDS);
+        createEventConsumerRunnable(postSystemUsecase, queue),
+        INITIAL_DELAY,
+        FIXED_DELAY,
+        TimeUnit.MILLISECONDS);
   }
 
-  private Runnable createEventConsumerRunnable(PostSystemUsecase postSystemUsecase, Queue<ViewPostEvent> queue) {
+  private Runnable createEventConsumerRunnable(
+      PostSystemUsecase postSystemUsecase, Queue<ViewPostEvent> queue) {
     return () -> {
       try {
         List<UpdateViewCountCommand> commands = new ArrayList<>();

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/message/InMemoryPostQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/message/InMemoryPostQueue.java
@@ -3,7 +3,6 @@ package com.flab.ccinside.api.trendingpost.adapter.out.post.message;
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import com.flab.ccinside.api.trendingpost.application.port.out.post.AsyncPublishAddViewCountPort;
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/message/InMemoryPostQueue.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/message/InMemoryPostQueue.java
@@ -2,6 +2,7 @@ package com.flab.ccinside.api.trendingpost.adapter.out.post.message;
 
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import com.flab.ccinside.api.trendingpost.application.port.out.post.AsyncPublishAddViewCountPort;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class InMemoryPostQueue implements AsyncPublishAddViewCountPort {
 
-  private final BlockingQueue<ViewPostEvent> queue;
+  private final Queue<ViewPostEvent> queue;
 
   @Override
   public void add(ViewPostEvent event) {

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostJpaRepository.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostJpaRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
+public interface PostJpaRepository extends JpaRepository<PostEntity, Long>, PostRepositorySupport {
 
   List<PostEntity> findByGalleryNo(Long galleryNo);
 

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostPersistenceAdapter.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostPersistenceAdapter.java
@@ -57,4 +57,10 @@ class PostPersistenceAdapter implements LoadPostPort, CreatePostPort, PersistPos
               postRepository.save(entity);
             });
   }
+
+  @Override
+  public void modifyInBatch(List<Post> posts) {
+    var postEntities = posts.stream().map(mapper::map).toList();
+    postRepository.saveAllByBatch(postEntities);
+  }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostRepositorySupport.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostRepositorySupport.java
@@ -1,0 +1,8 @@
+package com.flab.ccinside.api.trendingpost.adapter.out.post.persistence;
+
+import java.util.List;
+
+public interface PostRepositorySupport {
+
+  void saveAllByBatch(List<PostEntity> posts);
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostRepositorySupportImpl.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/adapter/out/post/persistence/PostRepositorySupportImpl.java
@@ -1,0 +1,21 @@
+package com.flab.ccinside.api.trendingpost.adapter.out.post.persistence;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class PostRepositorySupportImpl implements PostRepositorySupport {
+
+  @PersistenceContext private final EntityManager em;
+
+  @Override
+  public void saveAllByBatch(List<PostEntity> posts) {
+    posts.forEach(em::merge);
+    em.flush();
+    em.clear();
+  }
+}

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostSystemUsecase.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/in/PostSystemUsecase.java
@@ -1,6 +1,10 @@
 package com.flab.ccinside.api.trendingpost.application.port.in;
 
+import java.util.List;
+
 public interface PostSystemUsecase {
 
   void updateViewCount(UpdateViewCountCommand command);
+
+  void persistViewCountsInBatch(List<UpdateViewCountCommand> commands);
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/post/PersistPostViewPort.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/application/port/out/post/PersistPostViewPort.java
@@ -1,8 +1,11 @@
 package com.flab.ccinside.api.trendingpost.application.port.out.post;
 
 import com.flab.ccinside.api.trendingpost.domain.Post;
+import java.util.List;
 
 public interface PersistPostViewPort {
 
   void modify(Post post);
+
+  void modifyInBatch(List<Post> posts);
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
@@ -1,16 +1,18 @@
 package com.flab.ccinside.api.trendingpost.config;
 
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class InMemoryQueueConfig {
-
   @Bean
-  public BlockingQueue<ViewPostEvent> queue() {
-    return new LinkedBlockingQueue<>();
+  public Queue<ViewPostEvent> queue() {
+    return new ConcurrentLinkedQueue<>();
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
@@ -3,6 +3,8 @@ package com.flab.ccinside.api.trendingpost.config;
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +13,10 @@ public class InMemoryQueueConfig {
   @Bean
   public Queue<ViewPostEvent> queue() {
     return new ConcurrentLinkedQueue<>();
+  }
+
+  @Bean
+  public ScheduledExecutorService executorService() {
+    return Executors.newScheduledThreadPool(1);
   }
 }

--- a/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
+++ b/api/src/main/java/com/flab/ccinside/api/trendingpost/config/InMemoryQueueConfig.java
@@ -2,10 +2,7 @@ package com.flab.ccinside.api.trendingpost.config;
 
 import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent;
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/api/src/test/groovy/application/PostUserServiceSpec.groovy
+++ b/api/src/test/groovy/application/PostUserServiceSpec.groovy
@@ -2,6 +2,7 @@ package application
 
 import com.flab.ccinside.api.trendingpost.application.PostMapper
 import com.flab.ccinside.api.trendingpost.application.PostUserService
+import com.flab.ccinside.api.trendingpost.application.port.in.CreatePostCommand
 import com.flab.ccinside.api.trendingpost.application.port.out.PostId
 import com.flab.ccinside.api.trendingpost.application.port.out.post.AsyncPublishAddViewCountPort
 import com.flab.ccinside.api.trendingpost.application.port.out.post.CreatePostPort
@@ -30,8 +31,6 @@ class PostUserServiceSpec extends Specification {
     @SpringBean
     AsyncPublishAddViewCountPort publishAddViewCountPort = Mock()
 
-
-
     def "게시글 조회시, 조회 이벤트 발행 - 정상"() {
         given:
         var event = ViewPostEventFixture.VIEW_POSE_EVENT
@@ -42,9 +41,27 @@ class PostUserServiceSpec extends Specification {
         def got = postUserService.viewPostDetail(PostId.from(1L));
 
         then:
-        1 * publishAddViewCountPort.add({it == event})
+        1 * publishAddViewCountPort.add({ it == event })
         got.postTitle() == "test post title"
         got.authorNo() == 1L
         got.postNo() == 1L
+    }
+
+    def "게시글 생성 - 정상"() {
+        given:
+        def post = PostFixture.POST
+        var command = new CreatePostCommand(post.getPostTitle(), post.getAuthorNo(), post.getGalleryNo(), post.getViewCount())
+
+        when:
+        postUserService.create(command)
+
+        then:
+        1 * createPostPort.createPost({
+            it.postTitle == post.getPostTitle()
+            it.authorNo == post.getAuthorNo()
+            it.galleryNo == post.getGalleryNo()
+            it.viewCount == post.viewCount
+        })
+
     }
 }

--- a/api/src/test/groovy/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueueSpec.groovy
+++ b/api/src/test/groovy/com/flab/ccinside/api/trendingpost/adapter/in/message/InMemoryMessageQueueSpec.groovy
@@ -1,0 +1,44 @@
+package com.flab.ccinside.api.trendingpost.adapter.in.message
+
+import com.flab.ccinside.api.trendingpost.application.port.ViewPostEvent
+import com.flab.ccinside.api.trendingpost.application.port.in.PostSystemUsecase
+import com.flab.ccinside.api.trendingpost.application.port.in.UpdateViewCountCommand
+import com.flab.ccinside.api.trendingpost.application.port.out.PostId
+import com.flab.ccinside.api.trendingpost.config.InMemoryQueueConfig
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration(classes = [InMemoryMessageQueue, InMemoryQueueConfig])
+class InMemoryMessageQueueSpec extends Specification {
+
+    @Autowired
+    Queue<ViewPostEvent> queue
+
+    @SpringBean
+    ScheduledExecutorService executorService = Mock()
+
+    @SpringBean
+    PostSystemUsecase postSystemUsecase = Mock()
+
+    def "인메모리 메시지큐 이벤트 소비 및 행위 검증- 정상"() {
+        given:
+        def event = new ViewPostEvent(PostId.from(1L))
+
+        postSystemUsecase.updateViewCount(_) >> {}
+        postSystemUsecase.persistViewCountsInBatch(_) >> {}
+        1 * executorService.scheduleWithFixedDelay(_, _, _, _) >> { Runnable runnable, long l1, long l2, TimeUnit unit -> runnable.run()}
+
+        queue.add(event)
+
+        when:
+        def inMemoryMessageQueue = new InMemoryMessageQueue(postSystemUsecase, queue, executorService)
+
+        then:
+        1 * postSystemUsecase.updateViewCount({it == new UpdateViewCountCommand(PostId.from(1L))})
+        1 * postSystemUsecase.persistViewCountsInBatch({it == List.of(new UpdateViewCountCommand(PostId.from(1L)))})
+    }
+}

--- a/api/src/test/groovy/fixture/PostFixture.groovy
+++ b/api/src/test/groovy/fixture/PostFixture.groovy
@@ -7,5 +7,5 @@ import java.time.format.DateTimeFormatter
 
 class PostFixture {
 
-    static final Post POST = new Post(PostId.from(1L), "test post title", 1L, 1L, LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+    static final Post POST = new Post(PostId.from(1L), "test post title", 1L, 1L, 0, LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
 }


### PR DESCRIPTION
- fix: 인메모리 큐 사용하는 로직 생성자로 이관
- fix: 조회수 영속화 로직 변경
  - 기존: 스케줄러를 사용해 주기적으로 모든 게시글 업데이트
  - 수정: 주기적으로 업데이트 커맨드 병합 -> 조회 이벤트가 발생한 게시글만 배치 업데이트 

### Comment
뭔가 고민이 많았던 PR 이었습니다.
Write back 전략 자체는 괜찮은것 같은데, 결국 레디스 데이터를 mysql에 다시 쓰는 과정을 어떻게 할지가 관건이었네요!
다 구현하고보니.. 커맨드를 모아서 짧은 간격으로 배치 업데이트를 하는게 뭔가 괜찮은 방법같기도.. 하네요? ㅎㅎㅎ

배치 save를 위해 Jpa Repository의 save()를 사용하지 않고, entitymanager를 사용했는데요~
0.1초에 한 번씩 배치가 돌아간다고 생각하니 너무 잦은것 같기도 하고..
또 어떻게 보면 겨우 1초에 10번 WRITE하는 것으로 조회수 저장을 최적화 하는거니 괜찮은 것 같기도 하고..
이 부분에 대해서도 의견 주시면 감사드리겠습니다 :)